### PR TITLE
Coerce dates

### DIFF
--- a/lib/halation/coerce.rb
+++ b/lib/halation/coerce.rb
@@ -4,12 +4,12 @@ module Halation
 
     # @return [String, nil]
     def self.string(value)
-      value &&= value.to_s
+      value && value.to_s
     end
 
     # @return [Integer, nil]
     def self.integer(value)
-      value &&= value.to_i
+      value && value.to_i
     end
 
     # @return [Boolean]

--- a/lib/halation/coerce.rb
+++ b/lib/halation/coerce.rb
@@ -17,5 +17,10 @@ module Halation
       !!value
     end
 
+    # @return [Date, nil]
+    def self.date(value)
+      value && Time.parse(value)
+    end
+
   end
 end

--- a/lib/halation/engine.rb
+++ b/lib/halation/engine.rb
@@ -68,7 +68,7 @@ module Halation
           exif["Artist"] = @roll.artist || @config.artist
           exif["Copyright"] = @roll.copyright || @config.copyright
           
-          date_created = Time.new(frame.date || @roll.date)
+          date_created = frame.date || @roll.date
           exif["DateTimeOriginal"] = date_created
           exif["CreateDate"] = date_created
 

--- a/lib/halation/roll.rb
+++ b/lib/halation/roll.rb
@@ -9,7 +9,7 @@ module Halation
     attr_reader :artist
     # Copyright for the roll of film.
     attr_reader :copyright
-    # Default date for all frames (optional).
+    # Default date for all frames in ISO 8601 format (optional).
     attr_reader :date
     # Tag of the cameara used.
     attr_reader :camera
@@ -42,7 +42,7 @@ module Halation
       YAML.load_file(file_path).tap do |roll|
         @artist = Coerce.string(roll["artist"])
         @copyright = Coerce.string(roll["copyright"])
-        @date = Coerce.string(roll["date"])
+        @date = Coerce.date(roll["date"])
         @camera = Coerce.string(roll["camera"])
         @lens = Coerce.string(roll["lens"])
         @iso = Coerce.integer(roll["iso"])

--- a/lib/halation/roll/frame.rb
+++ b/lib/halation/roll/frame.rb
@@ -6,7 +6,7 @@ module Halation
     class Frame
       # Frame number.
       attr_reader :number
-      # Date the frame was taken.
+      # Date the frame was captured in ISO 8601 format.
       attr_reader :date
       # Tag of the lens used.
       attr_reader :lens
@@ -33,7 +33,7 @@ module Halation
 
       def initialize(yaml)
         @number = Coerce.integer(yaml["number"])
-        @date = Coerce.string(yaml["date"])
+        @date = Coerce.date(yaml["date"])
         @lens = Coerce.string(yaml["lens"])
         @focal_length = Coerce.integer(yaml["focal_length"])
         @shutter = Coerce.string(yaml["shutter"])

--- a/spec/coerce_spec.rb
+++ b/spec/coerce_spec.rb
@@ -32,4 +32,18 @@ describe Halation::Coerce do
       Coerce.integer(nil).should be nil
     end
   end
+
+  describe "a date" do
+    specify "from a string without a timestamp" do
+      Coerce.date("2016-02-03").should eq Time.parse("2016-02-03")
+    end
+
+    specify "from a string with a timestamp" do
+      Coerce.date("2016-02-03 01:02:03").should eq Time.parse("2016-02-03 01:02:03")
+    end
+
+    specify "from nil" do
+      Coerce.date(nil).should be nil
+    end
+  end
 end

--- a/spec/engine_spec.rb
+++ b/spec/engine_spec.rb
@@ -42,7 +42,7 @@ describe Halation::Engine do
     let(:exif_results) {[
       {
         # Frame 1
-        "DateTimeOriginal" => Time.new("2016-01-01"),
+        "DateTimeOriginal" => Time.parse("2016-02-03 01:02:03"),
         "LensModel" => "Z180mm f/4.5W-N",
         "ExposureTime" => 1.0/250,
         "FNumber" => 8,
@@ -52,7 +52,7 @@ describe Halation::Engine do
       },
       {
         # Frame 2
-        "DateTimeOriginal" => Time.new("2016-01-01"),
+        "DateTimeOriginal" => Time.parse("2016-01-02"),
         "LensModel" => "Z100-200mm f/5.2W",
         "ExposureTime" => 0.5,
         "FNumber" => 8,
@@ -62,7 +62,7 @@ describe Halation::Engine do
       },
       {
         # Frame 3
-        "DateTimeOriginal" => Time.new("2016-01-01"),
+        "DateTimeOriginal" => Time.parse("2016-01-02"),
         "LensModel" => "Z110mm f/2.8W",
         "ExposureTime" => 1.0/250,
         "FNumber" => 8,
@@ -72,7 +72,7 @@ describe Halation::Engine do
       },
       {
         # Frame 4
-        "DateTimeOriginal" => Time.new("2016-01-01"),
+        "DateTimeOriginal" => Time.parse("2016-01-02"),
         "LensModel" => "Z110mm f/2.8W",
         "ExposureTime" => 1.0/250,
         "FNumber" => 8,
@@ -82,7 +82,7 @@ describe Halation::Engine do
       },
       {
         # Frame 5
-        "DateTimeOriginal" => Time.new("2016-01-01"),
+        "DateTimeOriginal" => Time.parse("2016-01-02"),
         "LensModel" => "Z110mm f/2.8W",
         "ExposureTime" => 1.0/250,
         "FNumber" => 8,
@@ -92,7 +92,7 @@ describe Halation::Engine do
       },
       {
         # Frame 6
-        "DateTimeOriginal" => Time.new("2016-01-01"),
+        "DateTimeOriginal" => Time.parse("2016-01-02"),
         "LensModel" => "Z110mm f/2.8W",
         "ExposureTime" => 1.0/250,
         "FNumber" => 8,
@@ -102,7 +102,7 @@ describe Halation::Engine do
       },
       {
         # Frame 7
-        "DateTimeOriginal" => Time.new("2016-01-01"),
+        "DateTimeOriginal" => Time.parse("2016-01-02"),
         "LensModel" => "Z110mm f/2.8W",
         "ExposureTime" => 1.0/250,
         "FNumber" => 8,
@@ -112,7 +112,7 @@ describe Halation::Engine do
       },
       {
         # Frame 8
-        "DateTimeOriginal" => Time.new("2016-01-01"),
+        "DateTimeOriginal" => Time.parse("2016-01-02"),
         "LensModel" => "Z110mm f/2.8W",
         "ExposureTime" => 1.0/250,
         "FNumber" => 8,
@@ -122,7 +122,7 @@ describe Halation::Engine do
       },
       {
         # Frame 9
-        "DateTimeOriginal" => Time.new("2016-01-01"),
+        "DateTimeOriginal" => Time.parse("2016-01-02"),
         "LensModel" => "Z110mm f/2.8W",
         "ExposureTime" => 1.0/250,
         "FNumber" => 8,
@@ -132,7 +132,7 @@ describe Halation::Engine do
       },
       {
         # Frame 10
-        "DateTimeOriginal" => Time.new("2016-01-01"),
+        "DateTimeOriginal" => Time.parse("2016-01-02"),
         "LensModel" => "Z110mm f/2.8W",
         "ExposureTime" => 1.0/250,
         "FNumber" => 8,

--- a/spec/roll/frame_spec.rb
+++ b/spec/roll/frame_spec.rb
@@ -14,7 +14,7 @@ describe Halation::Roll::Frame do
 
   shared_examples :frame do
     its(:number) { should eq number.to_i }
-    its(:date) { should eq date.to_s }
+    its(:date) { should eq Time.parse(date) }
     its(:lens) { should eq lens.to_s }
     its(:focal_length) { should eq focal_length && focal_length.to_i }
     its(:shutter) { should eq shutter.to_s }

--- a/spec/roll_spec.rb
+++ b/spec/roll_spec.rb
@@ -27,7 +27,7 @@ describe Halation::Roll do
     it "has values" do
       subject.artist.should eq "Me"
       subject.copyright.should eq "2016 Me"
-      subject.date.should eq "2016-01-01"
+      subject.date.should eq Time.parse("2016-01-02")
       subject.camera.should eq "rz67"
       subject.lens.should eq "110"
       subject.iso.should eq 100
@@ -39,7 +39,7 @@ describe Halation::Roll do
         case i
         when 0
           frame.number.should eq 1
-          frame.date.should eq "2016-01-02"
+          frame.date.should eq Time.parse("2016-02-03 01:02:03")
           frame.lens.should eq "180"
           frame.focal_length.should be nil
           frame.shutter.should eq "1/250"

--- a/spec/samples/set_1/roll.yml
+++ b/spec/samples/set_1/roll.yml
@@ -1,13 +1,13 @@
 ---
 artist: "Me"
 copyright: "2016 Me"
-date: "2016-01-01" # default
+date: "2016-01-02" # default
 camera: "rz67"
 lens: 110 # default
 iso: 100
 frames:
   - number: 1
-    date: "2016-01-02" # overridden
+    date: "2016-02-03 01:02:03" # overridden
     lens: 180 # overridden
     shutter: "1/250"
     aperture: 8


### PR DESCRIPTION
Resolves #3 

This PR adds coercion for date strings to ruby `Time` objects, as well as refactoring the `Time.new` calls to `Time.parse`. These changes fix the issue of dates not being written to the Exif metadata correctly.