### PR TITLE
Refactor script to exit if a roll.yml file already exists

### DIFF
--- a/lib/halation/script.rb
+++ b/lib/halation/script.rb
@@ -48,7 +48,7 @@ module Halation
         end
 
         op.on("--new-roll", "Generate a new roll.yml file") do
-          generate_new_roll
+          generate_new_roll(opts)
           run_engine = false
           exit unless skip_exit
         end
@@ -82,12 +82,17 @@ module Halation
     # Generate a new roll.yml file.
     # Copies "~/.halation/templates/roll.yml" if it exists, otherwise it uses
     # a default template.
-    def self.generate_new_roll
+    #
+    # @option opts [Boolean] :skip_exit (false)
+    #   Don't exit the program after calling a handler that would normally exit.
+    #   Used for unit testing.
+    def self.generate_new_roll(opts = {})
+      skip_exit = !!opts[:skip_exit]
       roll_path = "roll.yml"
 
       if File.exists?(roll_path)
-        output_stream.puts "A roll.yml file already exists in this directory."
-        return
+        STDERR.puts "A roll.yml file already exists in this directory."
+        exit 1 unless skip_exit
       end
 
       # TODO: Make this configurable from config.yml

--- a/lib/halation/script.rb
+++ b/lib/halation/script.rb
@@ -21,61 +21,61 @@ module Halation
 
       options = {}
 
-      OptionParser.new { |opts|
-        opts.banner = "Usage: halation [options]"
+      OptionParser.new { |op|
+        op.banner = "Usage: halation [options]"
 
-        opts.on("-c", "--config=PATH", String, "Config file path") do |config_path|
+        op.on("-c", "--config=PATH", String, "Config file path") do |config_path|
           options[:config_path] = config_path
         end
 
-        opts.on("--dry", "Dry run") do
+        op.on("--dry", "Dry run") do
           options[:dry_run] = true
           # TODO: Implement
           raise NotImplementedError, "Dry run option is not yet implemented."
         end
 
-        opts.on("-h", "--help", "Print this help") do
-          output_stream.puts opts
+        op.on("-h", "--help", "Print this help") do
+          output_stream.puts op
           run_engine = false
           exit unless skip_exit
         end
 
-        opts.on("--new-config", "Generate a new config file") do |path|
+        op.on("--new-config", "Generate a new config file") do |path|
           # TODO: Implement
           raise NotImplementedError, "Generate config option is not yet implemented."
           run_engine = false
           exit unless skip_exit
         end
 
-        opts.on("--new-roll", "Generate a new roll.yml file") do
+        op.on("--new-roll", "Generate a new roll.yml file") do
           generate_new_roll
           run_engine = false
           exit unless skip_exit
         end
 
-        opts.on("-p", "--print-config", "Print the configuration settings") do
+        op.on("-p", "--print-config", "Print the configuration settings") do
           # TODO: Implement
           raise NotImplementedError, "Print config option is not yet implemented."
           run_engine = false
           exit unless skip_exit
         end
 
-        opts.on("-r", "--recursive", "Traverse into subdirectories") do
+        op.on("-r", "--recursive", "Traverse into subdirectories") do
           # TODO: Implement
           raise NotImplementedError, "Recursive option is not yet implemented."
         end
 
-        opts.on("--silent", "Suppress messages to stdout.") do
+        op.on("--silent", "Suppress messages to stdout.") do
           options[:silent] = true
         end
 
-        opts.on("-v", "--version", "Print the version information") do
+        op.on("-v", "--version", "Print the version information") do
           output_stream.puts "halation #{Halation::VERSION}"
           run_engine = false
           exit unless skip_exit
         end
       }.parse!(args)
-      
+
       Halation::Engine.run(options) if run_engine
     end
 

--- a/spec/script_spec.rb
+++ b/spec/script_spec.rb
@@ -51,6 +51,7 @@ describe Halation::Script do
 
     describe "(generated files)" do
       around { |test|
+        FileUtils.rm_r(working_dir) if Dir.exists?(working_dir)
         FileUtils.mkdir_p(working_dir)
         Dir.chdir(working_dir) { test.run }
         FileUtils.rm_r(working_dir)
@@ -71,6 +72,18 @@ describe Halation::Script do
 
           File.exists?(roll_path).should eq true
           Halation::Roll.new.load_file(roll_path)
+        end
+
+        specify "aborts if another roll exists" do
+          File.exists?(roll_path).should eq false
+
+          FileUtils.touch(roll_path)
+          File.exists?(roll_path).should eq true
+
+          allow(STDERR).to receive(:puts)
+          STDERR.should_receive(:puts).at_least(:once)
+
+          subject
         end
       end
     end


### PR DESCRIPTION
This fixes a crash that was happening when the script would try to create a `roll.yml` file in a directory that already contained one. It also corrects the error to print via `STDERR` and exit with a failure code.